### PR TITLE
Improve bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "main": [
     "assets/**/*"
-  ]
+  ],
   "ignore": [
     "**/.*",
     "assets/**/*.min.css",

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,6 @@
     "bower_components",
     "test",
     "tests",
-    "./*.html",
-    "assets/production"
+    "/*.html"
   ]
 }

--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
     "bower_components",
     "test",
     "tests",
-    "/*.html"
+    "/*.html",
+    "/*.png"
   ]
 }

--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,7 @@
     "John Slegers"
   ],
   "description": "CSS framework that puts back the C in CSS",
+  "main": "assets/css/cascade/development/build-full.css",
   "keywords": [
     "css",
     "js"
@@ -20,6 +21,8 @@
     "node_modules",
     "bower_components",
     "test",
-    "tests"
+    "tests",
+    "./*.html",
+    "assets/production"
   ]
 }

--- a/bower.json
+++ b/bower.json
@@ -11,8 +11,12 @@
     "js"
   ],
   "license": "MIT",
+  "main": [
+    "assets/**/*"
+  ]
   "ignore": [
     "**/.*",
+    "assets/**/*.min.css",
     "node_modules",
     "bower_components",
     "test",

--- a/bower.json
+++ b/bower.json
@@ -12,9 +12,6 @@
     "js"
   ],
   "license": "MIT",
-  "main": [
-    "assets/**/*"
-  ],
   "ignore": [
     "**/.*",
     "assets/**/*.min.css",


### PR DESCRIPTION
I've improved the bower.json file so as to ignore the minified JS (as recommended in the Bower docs), as well as all the HTML demo files (although those probably should get moved into gh-pages at some point).